### PR TITLE
chore(version): update version to 0.1.2 in project files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tp-auth-serverside"
-version = "0.1.1"
+version = "0.1.2"
 description = "A server side authentication utility which stores session tokens in memory db."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/tp_auth_serverside/core/fastapi_configurer.py
+++ b/src/tp_auth_serverside/core/fastapi_configurer.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional, Tuple
 from fastapi import APIRouter, Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
+from fastapi.responses import ORJSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from typing_extensions import Annotated
@@ -146,6 +147,7 @@ def generate_fastapi_app(
         redoc_url=app_config.redoc_url,
         lifespan=app_config.lifespan,
         exception_handlers=app_config.exception_handlers,
+        default_response_class=ORJSONResponse,
     )
     app.openapi = get_custom_api(app, app_config, disable_operation_default)
     if isinstance(health_check_routine, tuple):

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "tp-auth-serverside"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This pull request updates the FastAPI configuration to improve response performance and updates the project version. The most important changes are the switch to a faster JSON response class for all API responses and the version bump.

**FastAPI Response Optimization:**

* Set the default response class for the FastAPI app to `ORJSONResponse`, which provides faster JSON serialization and smaller payloads, improving API performance.
* Imported `ORJSONResponse` from `fastapi.responses` to support the new default response class.

**Project Versioning:**

* Updated the project version in `pyproject.toml` from `0.1.1` to `0.1.2` to reflect these changes.